### PR TITLE
Fix Chalk error

### DIFF
--- a/commands/neofetch.js
+++ b/commands/neofetch.js
@@ -12,7 +12,7 @@ import getRandInt from '../helpers/getRandInt.js';
 import getRandom from '../helpers/getRandom.js';
 import { DistroConfig, PromptConfig } from './neoconf.js';
 
-const chalk = Chalk({ level: 2 });
+const chalk = new Chalk({ level: 2 });
 
 export const data = new SlashCommandBuilder()
   .setName('neofetch')

--- a/commands/neofetch.js
+++ b/commands/neofetch.js
@@ -4,14 +4,15 @@ import { stripIndents } from 'common-tags';
 import fs from 'fs';
 import { fileURLToPath } from 'url';
 import path from 'path';
-import chalk from 'chalk';
-import chalkTemplate from 'chalk-template';
+import { Chalk } from 'chalk';
 import distroDetails from '../utils/distros.js';
 import prompts from '../utils/prompts.js';
 import embedColors from '../utils/embedColors.js';
 import getRandInt from '../helpers/getRandInt.js';
 import getRandom from '../helpers/getRandom.js';
 import { DistroConfig, PromptConfig } from './neoconf.js';
+
+const chalk = Chalk({ level: 2 });
 
 export const data = new SlashCommandBuilder()
   .setName('neofetch')
@@ -125,20 +126,20 @@ export async function execute(interaction) {
 
   // Replicates terminal colors that you would see
   // at the end of the neofetch command
-  const termColors = chalkTemplate`{blue ███}{green ███}{red ███}{yellow ███}{cyan ███}{magenta ███}{white ███}`;
+  const termColors = `${chalk.blue('███')}${chalk.green('███')}${chalk.red('███')}${chalk.yellow('███')}${chalk.cyan('███')}${chalk.magenta('███')}${chalk.white('███')}`; // prettier-ignore
 
   // Since each ascii art has exactly 12 lines and 21 columns per line,
   // the userDetails object will be formatted to fit the ascii art
   const userDetails = [
-    chalkTemplate`{green ${distroName}}`,
-    chalkTemplate`{red ---------------------}`,
-    chalkTemplate`{${distroColor}.bold Username}: ${details.username}`,
-    chalkTemplate`{${distroColor}.bold ID}: ${details.id}`,
-    chalkTemplate`{${distroColor}.bold Created}: ${details.createdAt}`,
-    chalkTemplate`{${distroColor}.bold Is Bot}: ${details.isBot}`,
-    chalkTemplate`{${distroColor}.bold CPU Usage}: ${cpu}%`,
-    chalkTemplate`{${distroColor}.bold Shell}: ${shell(distroShells)}`,
-    chalkTemplate`{${distroColor}.bold Packages}: ${packages} (${distroPackageManager})`,
+    chalk.green(`${distroName}`),
+    chalk.red('---------------------'),
+    `${chalk[distroColor].bold('Username')}: ${details.username}`,
+    `${chalk[distroColor].bold('ID')}: ${details.id}`,
+    `${chalk[distroColor].bold('Created')}: ${details.createdAt}`,
+    `${chalk[distroColor].bold('Is Bot')}: ${details.isBot}`,
+    `${chalk[distroColor].bold('CPU Usage')}: ${cpu}%`,
+    `${chalk[distroColor].bold('Shell')}: ${shell(distroShells)}`,
+    `${chalk[distroColor].bold('Packages')}: ${packages} (${distroPackageManager})`, // prettier-ignore
     '',
     termColors,
   ];

--- a/handlers/logHandler.js
+++ b/handlers/logHandler.js
@@ -1,6 +1,6 @@
 import { Chalk } from 'chalk';
 
-const chalk = Chalk({ level: 2 });
+const chalk = new Chalk({ level: 2 });
 
 const logger = {
   info: (message) => {

--- a/handlers/logHandler.js
+++ b/handlers/logHandler.js
@@ -1,4 +1,6 @@
-import chalk from 'chalk';
+import { Chalk } from 'chalk';
+
+const chalk = Chalk({ level: 2 });
 
 const logger = {
   info: (message) => {

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ console.clear();
 
 const token = process.env.TOKEN;
 
-const chalk = Chalk({ level: 2 });
+const chalk = new Chalk({ level: 2 });
 
 const client = new Client({
   intents: intentOptions,

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import { Client, Collection } from 'discord.js';
 import { config } from 'dotenv';
-import chalk from 'chalk';
+import { Chalk } from 'chalk';
 import fs from 'fs';
 import intentOptions from './config/intentOptions.js';
 import logger from './handlers/logHandler.js';
@@ -10,6 +10,8 @@ config();
 console.clear();
 
 const token = process.env.TOKEN;
+
+const chalk = Chalk({ level: 2 });
 
 const client = new Client({
   intents: intentOptions,

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@discordjs/builders": "^0.12.0",
         "@discordjs/rest": "^0.3.0",
         "chalk": "^5.0.0",
-        "chalk-template": "^0.3.1",
         "common-tags": "^1.8.2",
         "discord-api-types": "^0.26.1",
         "discord.js": "^13.6.0",
@@ -343,6 +342,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -357,6 +357,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -367,7 +368,8 @@
     "node_modules/ansi-styles/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/anymatch": {
       "version": "3.1.2",
@@ -672,35 +674,6 @@
       "integrity": "sha512-/duVOqst+luxCQRKEo4bNxinsOQtMP80ZYm7mMqzuh5PociNL0PvmHFvREJ9ueYL2TxlHjBcmLCdmocx9Vg+IQ==",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/chalk-template": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.3.1.tgz",
-      "integrity": "sha512-sbWkBbb9Tfo81aTtQrfP9eBSVCTL8biVvZ0tA1rH9xqVrKoV2T9Y6Bp94wB+DRXtSGl/UXsgV83Np5hLhNRXww==",
-      "dependencies": {
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk-template?sponsor=1"
-      }
-    },
-    "node_modules/chalk-template/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
@@ -1830,6 +1803,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -3517,6 +3491,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -4206,6 +4181,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "requires": {
         "color-convert": "^2.0.1"
       },
@@ -4214,6 +4190,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -4221,7 +4198,8 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
         }
       }
     },
@@ -4436,25 +4414,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.0.tgz",
       "integrity": "sha512-/duVOqst+luxCQRKEo4bNxinsOQtMP80ZYm7mMqzuh5PociNL0PvmHFvREJ9ueYL2TxlHjBcmLCdmocx9Vg+IQ=="
-    },
-    "chalk-template": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.3.1.tgz",
-      "integrity": "sha512-sbWkBbb9Tfo81aTtQrfP9eBSVCTL8biVvZ0tA1rH9xqVrKoV2T9Y6Bp94wB+DRXtSGl/UXsgV83Np5hLhNRXww==",
-      "requires": {
-        "chalk": "^4.1.2"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        }
-      }
     },
     "chokidar": {
       "version": "3.5.3",
@@ -5328,7 +5287,8 @@
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
     },
     "has-symbols": {
       "version": "1.0.2",
@@ -6541,6 +6501,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "requires": {
         "has-flag": "^4.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "@discordjs/builders": "^0.12.0",
     "@discordjs/rest": "^0.3.0",
     "chalk": "^5.0.0",
-    "chalk-template": "^0.3.1",
     "common-tags": "^1.8.2",
     "discord-api-types": "^0.26.1",
     "discord.js": "^13.6.0",

--- a/utils/prompts.js
+++ b/utils/prompts.js
@@ -1,4 +1,6 @@
-import chalk from 'chalk';
+import { Chalk } from 'chalk';
+
+const chalk = Chalk({ level: 2 });
 
 const prompts = {
   default: chalk.green(`discord ${chalk.blue('~$')}`),

--- a/utils/prompts.js
+++ b/utils/prompts.js
@@ -1,6 +1,6 @@
 import { Chalk } from 'chalk';
 
-const chalk = Chalk({ level: 2 });
+const chalk = new Chalk({ level: 2 });
 
 const prompts = {
   default: chalk.green(`discord ${chalk.blue('~$')}`),


### PR DESCRIPTION
This PR is a fix to an issue

Closes #1 (hopefully)

### Description

- Used a custom `Chalk` class with a custom level (level 2) to enforce terminal styling. Usually `chalk` would try to detect if the terminal supports color. If it doesn't it would disable color by setting the color level to 0, which would remove all styling. What I've done here is override the custom chalk level using a custom `Chalk` class, with options `{ level: 2 }` to force colors to display in the terminal

### Changes

- Use a custom `Chalk` class with custom options
- Remove `chalk-template` as it is no longer needed