### PR TITLE
Add buttons to main neofetch command and few other fixes

### DIFF
--- a/commands/info.js
+++ b/commands/info.js
@@ -1,12 +1,25 @@
 import { SlashCommandBuilder } from '@discordjs/builders';
 import ms from 'ms'; // Used to convert milliseconds to readable format
-import { MessageEmbed } from 'discord.js';
+import { MessageEmbed, MessageActionRow, MessageButton } from 'discord.js';
 
 export const data = new SlashCommandBuilder()
   .setName('info')
   .setDescription('Get information about the bot.');
 
 export async function execute(interaction) {
+  const infoActionRow = new MessageActionRow().addComponents(
+    new MessageButton()
+      .setLabel('View Source Code')
+      .setURL('https://github.com/savioxavier/discord-neofetch')
+      .setStyle('LINK')
+      .setEmoji('📃'),
+    new MessageButton()
+      .setLabel('Donate')
+      .setURL('https://buymeacoffee.com/savioxavier')
+      .setStyle('LINK')
+      .setEmoji('☕')
+  );
+
   const infoEmbed = new MessageEmbed()
     .setColor('#cd7b4a')
     .setAuthor({
@@ -33,5 +46,6 @@ export async function execute(interaction) {
   await interaction.reply({
     content: 'Some information about this cool bot:',
     embeds: [infoEmbed],
+    components: [infoActionRow],
   });
 }

--- a/commands/neoconf.js
+++ b/commands/neoconf.js
@@ -93,14 +93,16 @@ export async function execute(interaction) {
           `Updated distro choice for user ${interaction.user.id} to ${newDistro}`
         );
 
-        await interaction.reply(
-          `Successfully updated distro choice to ${newDistro}!`
-        );
+        await interaction.reply({
+          content: `Successfully updated distro choice to \`${newDistro}\`!`,
+          ephemeral: true,
+        });
       } catch (err) {
         logger.error(err);
-        await interaction.reply(
-          'Something went wrong trying to update your distro choice.'
-        );
+        await interaction.reply({
+          content: 'Something went wrong trying to update your distro choice.',
+          ephemeral: true,
+        });
       }
     }
 
@@ -113,14 +115,16 @@ export async function execute(interaction) {
           `Created new distro choice for user ${interaction.user.id} to ${newDistro}`
         );
 
-        await interaction.reply(
-          `Successfully set distro choice to ${newDistro}!`
-        );
+        await interaction.reply({
+          content: `Successfully set distro choice to \`${newDistro}\`!`,
+          ephemeral: true,
+        });
       } catch (err) {
         logger.error(err);
-        await interaction.reply(
-          'Something went wrong trying to create your distro choice.'
-        );
+        await interaction.reply({
+          content: 'Something went wrong trying to create your distro choice.',
+          ephemeral: true,
+        });
       }
     }
   } else if (interaction.options.getSubcommand() === 'prompt') {
@@ -147,14 +151,16 @@ export async function execute(interaction) {
           `Updated prompt choice for user ${interaction.user.id} to ${newPrompt}`
         );
 
-        await interaction.reply(
-          `Successfully updated prompt choice to ${newPrompt}!`
-        );
+        await interaction.reply({
+          content: `Successfully updated prompt choice to \`${newPrompt}\`!`,
+          ephemeral: true,
+        });
       } catch (err) {
         logger.error(err);
-        await interaction.reply(
-          'Something went wrong trying to update your prompt choice.'
-        );
+        await interaction.reply({
+          content: 'Something went wrong trying to update your prompt choice.',
+          ephemeral: true,
+        });
       }
     }
 
@@ -167,14 +173,16 @@ export async function execute(interaction) {
           `Created new prompt choice for user ${interaction.user.id} to ${newPrompt}`
         );
 
-        await interaction.reply(
-          `Successfully set prompt choice to ${newPrompt}!`
-        );
+        await interaction.reply({
+          content: `Successfully set prompt choice to \`${newPrompt}\`!`,
+          ephemeral: true,
+        });
       } catch (err) {
         logger.error(err);
-        await interaction.reply(
-          'Something went wrong trying to create your prompt choice.'
-        );
+        await interaction.reply({
+          content: 'Something went wrong trying to create your prompt choice.',
+          ephemeral: true,
+        });
       }
     }
   }

--- a/commands/neofetch.js
+++ b/commands/neofetch.js
@@ -195,7 +195,7 @@ export async function execute(interaction) {
     )
     .setFooter({
       text: 'Use /neoconf to configure',
-      iconURL: interaction.client.user.avatarURL(),
+      iconURL: interaction.user.avatarURL(),
     })
     .setColor(embedColors[distroColor])
     .setTimestamp();
@@ -221,7 +221,7 @@ export async function execute(interaction) {
     .setTimestamp()
     .setFooter({
       text: 'Use /neoconf to configure',
-      iconURL: interaction.client.user.avatarURL(),
+      iconURL: interaction.user.avatarURL(),
     });
 
   // Initialize new message button

--- a/commands/neofetch.js
+++ b/commands/neofetch.js
@@ -375,17 +375,9 @@ export async function execute(interaction) {
 
   // Handlers to disable the action row
   // after the time limit has passed
-  mobileButtonCollector.on('end', () =>
-    interaction.editReply({
-      components: [disabledActionRow],
-    })
-  );
-  helpButtonCollector.on('end', () =>
-    interaction.editReply({
-      components: [disabledActionRow],
-    })
-  );
-  deleteButtonCollector.on('end', () =>
+  const masterCollector = mobileButtonCollector; // Can be any of the button collectors, since they all have the same timeout
+
+  masterCollector.on('end', () =>
     interaction.editReply({
       components: [disabledActionRow],
     })

--- a/commands/neofetch.js
+++ b/commands/neofetch.js
@@ -294,7 +294,7 @@ export async function execute(interaction) {
           embeds: [mobileEmbed],
         });
       } catch (err) {
-        console.log(err);
+        // pass
       }
     }
   });
@@ -319,7 +319,7 @@ export async function execute(interaction) {
           embeds: [helpEmbed],
         });
       } catch (err) {
-        console.log(err);
+        // pass
       }
     }
   });
@@ -337,10 +337,9 @@ export async function execute(interaction) {
     if (action.customId === 'neofetch-delete') {
       try {
         await action.deferUpdate();
-        await wait(500);
         await action.deleteReply();
       } catch (err) {
-        console.log(err);
+        // pass
       }
     }
   });

--- a/commands/neomobile.js
+++ b/commands/neomobile.js
@@ -164,8 +164,12 @@ export async function execute(interaction) {
     randomTipElement !== '' ? `\n**__TIP__**: ${randomTipElement}` : '';
 
   // Finally, reply with the actual neofetch message
-  await interaction.reply({
-    content: `Here's your neofetch in mobile mode!${randomTip}`,
-    embeds: [mobileEmbed],
-  });
+  try {
+    await interaction.reply({
+      content: `Here's your neofetch in mobile mode!${randomTip}`,
+      embeds: [mobileEmbed],
+    });
+  } catch (err) {
+    // pass
+  }
 }

--- a/commands/neomobile.js
+++ b/commands/neomobile.js
@@ -138,7 +138,7 @@ export async function execute(interaction) {
     .setTimestamp()
     .setFooter({
       text: 'Use /neoconf to configure',
-      iconURL: interaction.client.user.avatarURL(),
+      iconURL: interaction.user.avatarURL(),
     });
 
   // Random tips that appear on the main neofetch message
@@ -165,7 +165,7 @@ export async function execute(interaction) {
 
   // Finally, reply with the actual neofetch message
   await interaction.reply({
-    content: `Not on PC? Seeing weird text? Try the **\`/neomobile\`** command instead.${randomTip}`,
+    content: `Here's your neofetch in mobile mode!${randomTip}`,
     embeds: [mobileEmbed],
   });
 }


### PR DESCRIPTION
This PR adds/updates the following stuff:

- Buttons for the main `neofetch` command
- Surround blocks with try/catch
- Buttons for the `info` command
- Update embed avatar images
- …and a few other fixes

Kept the `/neomobile` command for mobile users, even though there is a button for that now